### PR TITLE
Remove String Atom, only use RichAtom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /target
 user_mapping.amp
-user_store.ad3
 .env
 .vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ List of changes for this repo, including `atomic-cli`,
 - Fix cache-control header issue when opening a closed tab #137
 - Add collection properties `name`, `sortBy` and `sortDesc` #145
 - Extract `apply_changes` from `apply_commit`, make versioning safer and more reliable #146
+- Remove AD3 remnants, clean up code #148
 
 ## v0.24.1
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Atomic Data is heavily inspired by RDF (and converts nicely into RDF, as it is a
 
 This repository serves the following purposes:
 
-- Test and experiment with some of the core ideas of Atomic Data, such as [Atomic Schema](https://docs.atomicdata.dev/schema/intro.html) (share models and data types), [Paths](https://docs.atomicdata.dev/core/paths.html) (traversing data), [AD3 Serialization](https://docs.atomicdata.dev/core/serialization.html) and [Atomic Commits](https://docs.atomicdata.dev/commits/intro.html) (storing signed state changes).
+- Test and experiment with some of the core ideas of Atomic Data, such as [Atomic Schema](https://docs.atomicdata.dev/schema/intro.html) (share models and data types), [Paths](https://docs.atomicdata.dev/core/paths.html) (traversing data), [JSON-AD Serialization](https://docs.atomicdata.dev/core/json-ad.html) and [Atomic Commits](https://docs.atomicdata.dev/commits/intro.html) (storing signed state changes).
 - Serve the first Atomic Data, including the core schema (now available on [https://atomicdata.dev](https://atomicdata.dev)), which is referred to by the constantly evolving [docs](https://docs.atomicdata.dev/)
 - Provide developers with tools and inspiration to use Atomic Data in their own projects.
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -72,7 +72,7 @@ It will read the `~/.config/atomic/config.toml` file, and create one using some 
 
 ## Config
 
-Atomic creates a `~/.config/atomic` folder, which contains a `mapping.amp` and a `store.ad3`.
+Atomic creates a `~/.config/atomic` folder, which contains a `mapping.amp` and a `db`.
 This folder is also used by `atomic-server`.
 
 ## Mapping

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -300,8 +300,7 @@ fn tpf(context: &mut Context) -> AtomicResult<()> {
     let property = tpf_value(subcommand_matches.value_of("property").unwrap());
     let value = tpf_value(subcommand_matches.value_of("value").unwrap());
     let endpoint = format!("{}/tpf", &context.get_write_context().server);
-    let atoms = atomic_lib::client::fetch_tpf(&endpoint, subject, property, value)?;
-    let serialized = atomic_lib::serialize::serialize_atoms_to_ad3(atoms)?;
+    let serialized = atomic_lib::client::fetch_tpf(&endpoint, subject, property, value)?;
     println!("{}", serialized);
     Ok(())
 }

--- a/lib/examples/basic.rs
+++ b/lib/examples/basic.rs
@@ -11,7 +11,7 @@ fn main() {
     // Let's parse this AD3 string.
     let ad3 = r#"["https://localhost/test","https://atomicdata.dev/properties/description","Test"]"#;
     // The parser returns a Vector of Atoms
-    let atoms = atomic_lib::parse::parse_ad3(&ad3).unwrap();
+    let atoms = atomic_lib::parse::parse_ad3(&ad3, &store).unwrap();
     // Add the Atoms to the Store
     store.add_atoms(atoms).unwrap();
     // Get our resource...

--- a/lib/examples/basic.rs
+++ b/lib/examples/basic.rs
@@ -8,26 +8,7 @@ fn main() {
     // Pre-load the default Atomic Data Atoms (from atomicdata.dev),
     // this is not necessary, but will probably make your project a bit faster
     store.populate().unwrap();
-    // Let's parse this AD3 string.
-    let ad3 = r#"["https://localhost/test","https://atomicdata.dev/properties/description","Test"]"#;
-    // The parser returns a Vector of Atoms
-    let atoms = atomic_lib::parse::parse_ad3(&ad3, &store).unwrap();
-    // Add the Atoms to the Store
-    store.add_atoms(atoms).unwrap();
-    // Get our resource...
-    let my_resource = store.get_resource("https://localhost/test").unwrap();
-    // Get our value by filtering on our property...
-    let my_value = my_resource
-        .get("https://atomicdata.dev/properties/description")
-        .unwrap();
-    assert!(my_value.to_string() == "Test");
-    // We can also use the shortname of description
-    let my_value_from_shortname = my_resource.get_shortname("description", &store).unwrap();
-    assert!(my_value_from_shortname.to_string() == "Test");
-    // We can find any Atoms matching some value using Triple Pattern Fragments:
-    let found_atoms = store.tpf(None, None, Some("Test"), false).unwrap();
-    assert!(found_atoms.len() == 1);
-    // We can also create a new Resource, linked to the store.
+    // We can create a new Resource, linked to the store.
     // Note that since this store only exists in memory, it's data cannot be accessed from the internet.
     // Let's make a new Property instance! Let's create "age".
     let mut new_property = atomic_lib::Resource::new_instance("https://atomicdata.dev/classes/Property", &store).unwrap();

--- a/lib/src/atoms.rs
+++ b/lib/src/atoms.rs
@@ -1,7 +1,5 @@
 //! The smallest units of data, consiting of a Subject, a Property and a Value
 
-use crate::errors::AtomicResult;
-use crate::schema::Property;
 use crate::values::Value;
 use serde::Serialize;
 
@@ -11,11 +9,11 @@ use serde::Serialize;
 pub struct Atom {
     pub subject: String,
     pub property: String,
-    pub value: String,
+    pub value: Value,
 }
 
 impl Atom {
-    pub fn new(subject: String, property: String, value: String) -> Self {
+    pub fn new(subject: String, property: String, value: Value) -> Self {
         Atom {
             subject,
             property,
@@ -28,36 +26,5 @@ impl std::fmt::Display for Atom {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
         fmt.write_str(&format!("<{}> <{}> '{}'", self.subject, self.property, self.value))?;
         Ok(())
-    }
-}
-
-/// A more heavyweight atom that is validated,
-/// converted to a native value and has various property details.
-#[derive(Clone, Debug, Serialize)]
-pub struct RichAtom {
-    pub subject: String,
-    pub property: Property,
-    pub value: String,
-    pub native_value: Value,
-}
-
-impl RichAtom {
-    pub fn new(subject: String, property: Property, value: String) -> AtomicResult<Self> {
-        Ok(RichAtom {
-            subject,
-            property: property.clone(),
-            value: value.clone(),
-            native_value: Value::new(&value, &property.data_type)?,
-        })
-    }
-}
-
-impl From<RichAtom> for Atom {
-    fn from(richatom: RichAtom) -> Self {
-        Atom::new(
-            richatom.subject,
-            richatom.property.subject,
-            richatom.value,
-        )
     }
 }

--- a/lib/src/client.rs
+++ b/lib/src/client.rs
@@ -1,37 +1,34 @@
 //! Functions for interacting with an Atomic Server
 use url::Url;
 
-use crate::{errors::AtomicResult, parse::parse_ad3, Resource, Storelike};
-
-fn fetch_atoms(url: &str, store: &impl Storelike) -> AtomicResult<Vec<crate::Atom>> {
-    if !url.starts_with("http") {
-        return Err(format!("Could not fetch url '{}', must start with http.", url).into());
-    }
-    let resp = ureq::get(&url)
-        .set("Accept", crate::parse::AD3_MIME)
-        .timeout_read(2000)
-        .call();
-    if resp.status() != 200 {
-        return Err(format!("Could not fetch url '{}'. Status: {}", url, resp.status()).into());
-    };
-    let body = &resp
-        .into_string()
-        .map_err(|e| format!("Could not parse response {}: {}", url, e))?;
-    let atoms = parse_ad3(body, store).map_err(|e| format!("Error parsing body of {}: {}", url, e))?;
-    Ok(atoms)
-}
+use crate::{Resource, Storelike, errors::AtomicResult, parse::parse_json_ad_resource};
 
 /// Fetches a resource, makes sure its subject matches.
 /// Checks the datatypes for the Values.
 /// Ignores all atoms where the subject is different.
 /// WARNING: Calls store methods, and is called by store methods, might get stuck in a loop!
 pub fn fetch_resource(subject: &str, store: &impl Storelike) -> AtomicResult<Resource> {
-    let atoms = fetch_atoms(subject, store)?;
-    let mut resource = Resource::new(subject.into());
-    for atom in atoms {
-        resource.set_propval(atom.property, atom.value, store)?;
-    }
+    let body = fetch_body(subject, crate::parse::JSON_AD_MIME)?;
+    let resource = parse_json_ad_resource(&body, store).map_err(|e| format!("Error parsing body of {}: {}", subject, e))?;
     Ok(resource)
+}
+
+/// Fetches a URL, returns its body
+pub fn fetch_body(url: &str, content_type: &str) -> AtomicResult<String> {
+    if !url.starts_with("http") {
+        return Err(format!("Could not fetch url '{}', must start with http.", url).into());
+    }
+    let resp = ureq::get(&url)
+        .set("Accept", content_type)
+        .timeout_read(2000)
+        .call();
+    if resp.status() != 200 {
+        return Err(format!("Could not fetch url '{}'. Status: {}", url, resp.status()).into());
+    };
+    let body = resp
+        .into_string()
+        .map_err(|e| format!("Could not parse response {}: {}", url, e))?;
+    Ok(body)
 }
 
 /// Uses a TPF endpoint, fetches the atoms.
@@ -40,8 +37,7 @@ pub fn fetch_tpf(
     q_subject: Option<&str>,
     q_property: Option<&str>,
     q_value: Option<&str>,
-    store: &impl Storelike,
-) -> AtomicResult<Vec<crate::Atom>> {
+) -> AtomicResult<String> {
     let mut url = Url::parse(endpoint)?;
     if let Some(val) = q_subject {
         url.query_pairs_mut().append_pair("subject", val);
@@ -52,8 +48,7 @@ pub fn fetch_tpf(
     if let Some(val) = q_value {
         url.query_pairs_mut().append_pair("value", val);
     }
-    // let url = "https://atomicdata.dev/tpf?subject=&property=&value=1";
-    fetch_atoms(url.as_str(), store)
+    fetch_body(url.as_str(), "application/n-triples")
 }
 
 /// Posts a Commit to the endpoint of the Subject from the Commit

--- a/lib/src/collections.rs
+++ b/lib/src/collections.rs
@@ -393,7 +393,7 @@ mod test {
                 .get(urls::COLLECTION_MEMBER_COUNT)
                 .unwrap()
                 .to_string()
-                , "14"
+                , "12"
         );
     }
 

--- a/lib/src/db.rs
+++ b/lib/src/db.rs
@@ -97,14 +97,14 @@ impl Storelike for Db {
                 // Resource exists in map
                 Some(resource) => {
                     resource
-                        .set_propval_string(atom.property.clone(), &atom.value, self)
+                        .set_propval_string(atom.property.clone(), &atom.value.to_string(), self)
                         .map_err(|e| format!("Failed adding attom {}. {}", atom, e))?;
                 }
                 // Resource does not exist
                 None => {
                     let mut resource = Resource::new(atom.subject.clone());
                     resource
-                        .set_propval_string(atom.property.clone(), &atom.value, self)
+                        .set_propval_string(atom.property.clone(), &atom.value.to_string(), self)
                         .map_err(|e| format!("Failed adding attom {}. {}", atom, e))?;
                     map.insert(atom.subject, resource);
                 }
@@ -303,7 +303,7 @@ mod test {
         let ad3 =
             r#"["https://localhost/test","https://atomicdata.dev/properties/description","Test"]"#;
         // The parser returns a Vector of Atoms
-        let atoms = crate::parse::parse_ad3(&ad3).unwrap();
+        let atoms = crate::parse::parse_ad3(&ad3, &store).unwrap();
         // Add the Atoms to the Store
         store.add_atoms(atoms).unwrap();
         // Get our resource...
@@ -319,7 +319,7 @@ mod test {
         // We can find any Atoms matching some value using Triple Pattern Fragments:
         let found_atoms = store.tpf(None, None, Some("Test"), true).unwrap();
         assert!(found_atoms.len() == 1);
-        assert!(found_atoms[0].value == "Test");
+        assert!(found_atoms[0].value.to_string() == "Test");
 
         // We can also create a new Resource, linked to the store.
         // Note that since this store only exists in memory, it's data cannot be accessed from the internet.

--- a/lib/src/db.rs
+++ b/lib/src/db.rs
@@ -299,29 +299,7 @@ mod test {
     #[timeout(30000)]
     fn basic() {
         let store = DB.lock().unwrap().clone();
-        // Let's parse this AD3 string.
-        let ad3 =
-            r#"["https://localhost/test","https://atomicdata.dev/properties/description","Test"]"#;
-        // The parser returns a Vector of Atoms
-        let atoms = crate::parse::parse_ad3(&ad3, &store).unwrap();
-        // Add the Atoms to the Store
-        store.add_atoms(atoms).unwrap();
-        // Get our resource...
-        let my_resource = store.get_resource("https://localhost/test").unwrap();
-        // Get our value by filtering on our property...
-        let my_value = my_resource
-            .get("https://atomicdata.dev/properties/description")
-            .unwrap();
-        assert!(my_value.to_string() == "Test");
-        // We can also use the shortname of description
-        let my_value_from_shortname = my_resource.get_shortname("description", &store).unwrap();
-        assert!(my_value_from_shortname.to_string() == "Test");
-        // We can find any Atoms matching some value using Triple Pattern Fragments:
-        let found_atoms = store.tpf(None, None, Some("Test"), true).unwrap();
-        assert!(found_atoms.len() == 1);
-        assert!(found_atoms[0].value.to_string() == "Test");
-
-        // We can also create a new Resource, linked to the store.
+        // We can create a new Resource, linked to the store.
         // Note that since this store only exists in memory, it's data cannot be accessed from the internet.
         // Let's make a new Property instance!
         let mut new_property =

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -13,26 +13,7 @@ let store = atomic_lib::Store::init().unwrap();
 // Pre-load the default Atomic Data Atoms (from atomicdata.dev),
 // this is not necessary, but will probably make your project a bit faster
 store.populate().unwrap();
-// Let's parse this AD3 string.
-let ad3 = r#"["https://localhost/test","https://atomicdata.dev/properties/description","Test"]"#;
-// The parser returns a Vector of Atoms
-let atoms = atomic_lib::parse::parse_ad3(&ad3).unwrap();
-// Add the Atoms to the Store
-store.add_atoms(atoms).unwrap();
-// Get our resource...
-let my_resource = store.get_resource("https://localhost/test").unwrap();
-// Get our value by filtering on our property...
-let my_value = my_resource
-    .get("https://atomicdata.dev/properties/description")
-    .unwrap();
-assert!(my_value.to_string() == "Test");
-// We can also use the shortname of description
-let my_value_from_shortname = my_resource.get_shortname("description", &store).unwrap();
-assert!(my_value_from_shortname.to_string() == "Test");
-// We can find any Atoms matching some value using Triple Pattern Fragments:
-let found_atoms = store.tpf(None, None, Some("Test"), false).unwrap();
-assert!(found_atoms.len() == 1);
-// We can also create a new Resource, linked to the store.
+// We can create a new Resource, linked to the store.
 // Note that since this store only exists in memory, it's data cannot be accessed from the internet.
 // Let's make a new Property instance! Let's create "age".
 let mut new_property = atomic_lib::Resource::new_instance("https://atomicdata.dev/classes/Property", &store).unwrap();

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -91,7 +91,6 @@ pub mod validate;
 pub mod values;
 
 pub use atoms::Atom;
-pub use atoms::RichAtom;
 #[cfg(feature = "db")]
 pub use db::Db;
 pub use commit::Commit;

--- a/lib/src/parse.rs
+++ b/lib/src/parse.rs
@@ -4,9 +4,10 @@ use crate::{errors::AtomicResult, resources::PropVals, urls, Atom, Resource, Sto
 
 pub const AD3_MIME: &str = "application/ad3-ndjson";
 
-/// Parses an Atomic Data Triples (.ad3) string and adds the Atoms to the store.
+/// Parses an Atomic Data Triples (.ad3) string.
+/// Does not add the Atoms to the store - use store.add_atoms() for that.
 /// Allows comments and empty lines.
-pub fn parse_ad3(string: &str) -> AtomicResult<Vec<Atom>> {
+pub fn parse_ad3(string: &str, store: &impl Storelike) -> AtomicResult<Vec<Atom>> {
     let mut atoms: Vec<Atom> = Vec::new();
     for line in string.lines() {
         match line.chars().next() {
@@ -28,7 +29,9 @@ pub fn parse_ad3(string: &str) -> AtomicResult<Vec<Atom>> {
                 }
                 let subject = string_vec[0].clone();
                 let property = string_vec[1].clone();
-                let value = string_vec[2].clone();
+                let value_string = string_vec[2].clone();
+                let datatype = store.get_property(&property)?.data_type;
+                let value = Value::new(&value_string, &datatype)?;
                 atoms.push(Atom::new(subject, property, value));
             }
             Some(char) => {

--- a/lib/src/plugins/path.rs
+++ b/lib/src/plugins/path.rs
@@ -29,10 +29,10 @@ fn handle_path_request(url: url::Url, store: &impl Storelike) -> AtomicResult<Re
             resource.set_propval_string(urls::ATOM_SUBJECT.into(), &atom.subject, store)?;
             resource.set_propval_string(
                 urls::ATOM_PROPERTY.into(),
-                &atom.property.subject,
+                &atom.property,
                 store,
             )?;
-            resource.set_propval_string(urls::ATOM_VALUE.into(), &atom.value, store)?;
+            resource.set_propval_string(urls::ATOM_VALUE.into(), &atom.value.to_string(), store)?;
             Ok(resource)
         }
     }

--- a/lib/src/plugins/versioning.rs
+++ b/lib/src/plugins/versioning.rs
@@ -1,4 +1,4 @@
-use crate::{Commit, Resource, Store, Storelike, Value, collections::CollectionBuilder, endpoints::Endpoint, errors::AtomicResult, urls};
+use crate::{Commit, Resource, Storelike, collections::CollectionBuilder, endpoints::Endpoint, errors::AtomicResult, urls};
 
 pub fn version_endpoint() -> Endpoint {
     Endpoint {

--- a/lib/src/resources.rs
+++ b/lib/src/resources.rs
@@ -355,7 +355,7 @@ impl Resource {
             let atom = Atom::new(
                 self.subject.to_string(),
                 property.clone(),
-                value.to_string(),
+                value.clone(),
             );
             atoms.push(atom);
         }

--- a/lib/src/resources.rs
+++ b/lib/src/resources.rs
@@ -303,20 +303,6 @@ impl Resource {
         self.subject = url;
     }
 
-    /// Serializes Resource to Atomic Data Triples (ad3), and NDJSON serialized representation.
-    pub fn to_ad3(&self) -> AtomicResult<String> {
-        let mut string = String::new();
-        let resource = self.get_propvals();
-
-        for (property, value) in resource {
-            let mut ad3_atom =
-                serde_json::to_string(&vec![self.get_subject(), &property, &value.to_string()])?;
-            ad3_atom.push('\n');
-            string.push_str(&*ad3_atom);
-        }
-        Ok(string)
-    }
-
     /// Converts Resource to JSON-AD string.
     pub fn to_json_ad(&self) -> AtomicResult<String> {
         let obj = crate::serialize::propvals_to_json_map(

--- a/lib/src/serialize.rs
+++ b/lib/src/serialize.rs
@@ -1,10 +1,10 @@
-//! Serialization / formatting / encoding (JSON, RDF, N-Triples, AD3)
+//! Serialization / formatting / encoding (JSON, RDF, N-Triples)
 
 use serde_json::Map;
 use serde_json::Value as SerdeValue;
 
 use crate::{
-    datatype::DataType, errors::AtomicResult, resources::PropVals, Atom, Resource, Storelike, Value,
+    datatype::DataType, errors::AtomicResult, resources::PropVals, Resource, Storelike, Value, Atom
 };
 
 /// Serializes a vector or Resources to a JSON-AD string
@@ -139,19 +139,6 @@ pub fn serialize_json_array(items: &[String]) -> AtomicResult<String> {
     Ok(string)
 }
 
-/// Serializes Atoms to .ad3.
-/// It is a newline-delimited JSON file (ndjson), where each line is a JSON Array with three string values.
-pub fn serialize_atoms_to_ad3(atoms: Vec<Atom>) -> AtomicResult<String> {
-    let mut string = String::new();
-    for atom in atoms {
-        let mut ad3_atom =
-            serde_json::to_string(&vec![&atom.subject, &atom.property, &atom.value.to_string()])?;
-        ad3_atom.push('\n');
-        string.push_str(&*ad3_atom);
-    }
-    Ok(string)
-}
-
 #[cfg(feature = "rdf")]
 /// Serializes Atoms to Ntriples (which is also valid Turtle / Notation3).
 pub fn atoms_to_ntriples(atoms: Vec<Atom>, store: &impl Storelike) -> AtomicResult<String> {
@@ -196,7 +183,6 @@ pub fn atoms_to_turtle(atoms: Vec<Atom>, store: &impl Storelike) -> AtomicResult
     use rio_api::formatter::TriplesFormatter;
     use rio_api::model::{Literal, NamedNode, Term, Triple};
     use rio_turtle::TurtleFormatter;
-
     let mut formatter = TurtleFormatter::new(Vec::default());
 
     for atom in atoms {
@@ -234,7 +220,6 @@ pub enum Format {
     JSON,
     JSONAD,
     JSONLD,
-    AD3,
     NT,
     PRETTY,
 }

--- a/lib/src/storelike.rs
+++ b/lib/src/storelike.rs
@@ -5,12 +5,12 @@ use crate::{
     agents::Agent,
     schema::{Class, Property},
 };
-use crate::{mapping::Mapping, values::Value, Atom, Resource, RichAtom};
+use crate::{mapping::Mapping, values::Value, Atom, Resource};
 
 // A path can return one of many things
 pub enum PathReturn {
     Subject(String),
-    Atom(Box<RichAtom>),
+    Atom(Box<Atom>),
 }
 
 pub type ResourceCollection = Vec<Resource>;
@@ -189,7 +189,7 @@ pub trait Storelike: Sized {
                     vec.push(Atom::new(
                         resource.get_subject().clone(),
                         property.clone(),
-                        value.to_string(),
+                        value.clone()
                     ))
                 }
             }
@@ -217,15 +217,15 @@ pub trait Storelike: Sized {
                 if hasprop && q_property.as_ref().unwrap() == prop {
                     if hasval {
                         if val_equals(&val.to_string()) {
-                            vec.push(Atom::new(subj.into(), prop.into(), val.to_string()))
+                            vec.push(Atom::new(subj.into(), prop.into(), val.clone()))
                         }
                         break;
                     } else {
-                        vec.push(Atom::new(subj.into(), prop.into(), val.to_string()))
+                        vec.push(Atom::new(subj.into(), prop.into(), val.clone()))
                     }
                     break;
                 } else if hasval && !hasprop && val_equals(&val.to_string()) {
-                    vec.push(Atom::new(subj.into(), prop.into(), val.to_string()))
+                    vec.push(Atom::new(subj.into(), prop.into(), val.clone()))
                 }
             }
         };
@@ -289,7 +289,7 @@ pub trait Storelike: Sized {
             if let Ok(i) = item.parse::<u32>() {
                 match current {
                     PathReturn::Atom(atom) => {
-                        let vector = match resource.get(&atom.property.subject)? {
+                        let vector = match resource.get(&atom.property)? {
                             Value::ResourceArray(vec) => vec,
                             _ => return Err("Should be Vector!".into()),
                         };
@@ -323,11 +323,11 @@ pub trait Storelike: Sized {
             // TODO: skip this step if the current iteration is the last one
             let value = resource.get_shortname(&item, self)?.clone();
             let property = resource.resolve_shortname_to_property(item, self)?;
-            current = PathReturn::Atom(Box::new(RichAtom::new(
+            current = PathReturn::Atom(Box::new(Atom::new(
                 subject.clone(),
-                property,
-                value.to_string(),
-            )?))
+                property.subject,
+                value,
+            )))
         }
         Ok(current)
     }

--- a/lib/src/test_utils.rs
+++ b/lib/src/test_utils.rs
@@ -1,14 +1,10 @@
-use crate::{Store, Storelike, parse::parse_ad3};
+use crate::{Store, Storelike};
 
 /// Creates a populated Store with an agent (testman) and one test resource (_:test)
 pub fn init_store() -> Store {
-  let string =
-      String::from("[\"_:test\",\"https://atomicdata.dev/properties/shortname\",\"hi\"]");
   let store = Store::init().unwrap();
   store.populate().unwrap();
-  let atoms = parse_ad3(&string).unwrap();
   let agent = store.create_agent(None).unwrap();
   store.set_default_agent(agent);
-  store.add_atoms(atoms).unwrap();
   store
 }

--- a/lib/src/validate.rs
+++ b/lib/src/validate.rs
@@ -56,7 +56,7 @@ pub fn validate_store(
             match crate::Value::new(&value.to_string(), &property.data_type) {
                 Ok(_) => {}
                 Err(e) => invalid_value.push((
-                    crate::Atom::new(subject.clone(), prop_url.clone(), value.to_string()),
+                    crate::Atom::new(subject.clone(), prop_url.clone(), value),
                     e.to_string(),
                 )),
             };
@@ -160,7 +160,7 @@ mod test {
     fn invalid_ad3() {
         let store = Store::init().unwrap();
         let ad3 = r#"["https://example.com","https://atomicdata.dev/properties/isA","[\"https://atomicdata.dev/classes/Class\"]"]"#;
-        let atoms = parse_ad3(ad3).unwrap();
+        let atoms = parse_ad3(ad3, &store).unwrap();
         // This used to work, but now the add_atoms process does all the validation. It already checks completeness of resource and datatype compliance.
         store.add_atoms(atoms).unwrap_err();
         // let report = validate_store(&store, false);

--- a/lib/src/validate.rs
+++ b/lib/src/validate.rs
@@ -144,7 +144,7 @@ impl std::fmt::Display for ValidationReport {
 
 #[cfg(test)]
 mod test {
-    use crate::{parse::parse_ad3, Store, Storelike};
+    use crate::{Store, Storelike};
 
     #[test]
     fn validate_populated() {
@@ -154,20 +154,5 @@ mod test {
         // assert!(report.atom_count > 30);
         // assert!(report.resource_count > 5);
         // assert!(report.is_valid());
-    }
-
-    #[test]
-    fn invalid_ad3() {
-        let store = Store::init().unwrap();
-        let ad3 = r#"["https://example.com","https://atomicdata.dev/properties/isA","[\"https://atomicdata.dev/classes/Class\"]"]"#;
-        let atoms = parse_ad3(ad3, &store).unwrap();
-        // This used to work, but now the add_atoms process does all the validation. It already checks completeness of resource and datatype compliance.
-        store.add_atoms(atoms).unwrap_err();
-        // let report = validate_store(&store, false);
-        // println!("resource_count: {}", report.resource_count);
-        // assert!(report.resource_count == 10);
-        // println!("atom_count: {}", report.atom_count);
-        // assert!(report.atom_count == 44);
-        // assert!(!report.is_valid());
     }
 }

--- a/server/example_requests.http
+++ b/server/example_requests.http
@@ -10,21 +10,9 @@ Accept: application/ad+json
 GET https://atomicdata.dev/properties/isA HTTP/1.1
 Accept: application/ld+json
 
-### Get a thing as AD3
-GET https://atomicdata.dev/properties/isA HTTP/1.1
-Accept: application/ad3-ndjson
-
 ### Get a thing as turtle
 GET https://atomicdata.dev/properties/isA HTTP/1.1
 Accept: text/turtle
-
-### Use TPF endpoint to get all atoms with an 'isA' property
-GET https://atomicdata.dev/tpf?property=https://atomicdata.dev/properties/isA HTTP/1.1
-Accept: application/ad3-ndjson
-
-### Use Path endpoint to retrieve a resource or a path
-GET https://atomicdata.dev/path?path=https://atomicdata.dev/properties/isA HTTP/1.1
-Accept: application/ad3-ndjson
 
 ### Send a Commit
 POST http://localhost/commit HTTP/1.1
@@ -42,7 +30,3 @@ Content-Type: application/json
   "destroy": false,
   "signature": "correct_signature"
 }
-
-### Check if above commit has been applied correctly
-GET http://localhost/somresource HTTP/1.1
-Accept: application/ad3-ndjson

--- a/server/src/content_types.rs
+++ b/server/src/content_types.rs
@@ -20,11 +20,8 @@ pub enum ContentType {
     /// RDF N-Triples format
     /// https://www.w3.org/TR/n-triples/
     NT,
-    /// Atomic Data Triples (deprecated)
-    AD3,
 }
 
-const MIME_AD3: &str = "application/ad3-ndjson";
 const MIME_HTML: &str = "text/html";
 const MIME_XML: &str = "application/xml";
 const MIME_JSON: &str = "application/json";
@@ -41,7 +38,6 @@ impl ContentType {
             ContentType::JSONLD => MIME_JSONLD,
             ContentType::HTML => MIME_HTML,
             ContentType::TURTLE => MIME_TURTLE,
-            ContentType::AD3 => MIME_AD3,
             ContentType::NT => MIME_NT
         }
     }
@@ -69,9 +65,6 @@ pub fn parse_accept_header(header: &str) -> ContentType {
     for mimepart in header.split(',') {
         if mimepart.contains(MIME_JSONAD) {
             return ContentType::JSONAD
-        }
-        if mimepart.contains(MIME_AD3) {
-            return ContentType::AD3
         }
         if mimepart.contains(MIME_HTML) {
             return ContentType::HTML
@@ -103,14 +96,13 @@ mod test {
     #[test]
     fn parse_types() {
         assert!(parse_accept_header("text/html,application/xml") == ContentType::HTML);
-        assert!(parse_accept_header("application/ad3-ndjson") == ContentType::AD3);
         assert!(parse_accept_header("application/ad+json") == ContentType::JSONAD);
         assert!(parse_accept_header("application/ld+json") == ContentType::JSONLD);
     }
 
     #[test]
     fn parse_types_with_blank_chars() {
-        assert!(parse_accept_header("application/ad3-ndjson ; ") == ContentType::AD3);
-        assert!(parse_accept_header(" application/ad3-ndjson ; ") == ContentType::AD3);
+        assert!(parse_accept_header("application/ad+json ; ") == ContentType::JSONAD);
+        assert!(parse_accept_header(" application/ad+json ; ") == ContentType::JSONAD);
     }
 }

--- a/server/src/handlers/resource.rs
+++ b/server/src/handlers/resource.rs
@@ -68,10 +68,6 @@ pub async fn get_resource(
             let body = resource.to_json_ad()?;
             Ok(builder.body(body))
         }
-        ContentType::AD3 => {
-            let body = resource.to_ad3()?;
-            Ok(builder.body(body))
-        }
         ContentType::TURTLE | ContentType::NT => {
             let atoms = resource.to_atoms()?;
             let body = atomic_lib::serialize::atoms_to_ntriples(atoms, store)?;
@@ -86,7 +82,6 @@ fn try_extension(path: &str) -> Option<(ContentType, &str)> {
     if items.len() == 2 {
         let path = items[0];
         let content_type = match items[1] {
-            "ad3" => ContentType::AD3,
             "json" => ContentType::JSON,
             "jsonld" => ContentType::JSONLD,
             "jsonad" => ContentType::JSONAD,

--- a/server/src/handlers/tpf.rs
+++ b/server/src/handlers/tpf.rs
@@ -37,11 +37,6 @@ pub async fn tpf(
             log::error!("Not implemented");
             Ok(builder.body("Not implemented"))
         }
-        ContentType::AD3 => {
-            builder.header("Content-Type", content_type.to_mime());
-            let ad3_string = atomic_lib::serialize::serialize_atoms_to_ad3(atoms)?;
-            Ok(builder.body(ad3_string))
-        }
         ContentType::TURTLE | ContentType::NT => {
             builder.header("Content-Type", content_type.to_mime());
             let bod_string = atomic_lib::serialize::atoms_to_ntriples(atoms, store)?;


### PR DESCRIPTION
The first store was string based, and the Resource model was String based too. This, however, led to incorrect datatypes. I made the store stricter by storing Enum Values. This PR cleans up the last remnants of this older data model.

But I'm not 100% sure that the string based atoms have no value / no reason to exist. That's why this isn't merged yet.