### PR TITLE
Migrations in Sled KV store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ By far most changes relate to `atomic-server`, so if not specified, assume the c
 
 ## UNRELEASED
 
-- **Warning**: Various default directories have moved (see #331). Most notably the `data` directory. The location depends on your OS. Run `show-config` to see where it will be stored now. If you have data in `~/.config/atomic/db`, move it to this new directory.
-- **Warning**: Search index will have to be rebuilt. Start with `--rebuild-index`.
+- **Warning**: Various default directories have moved (see #331). Most notably the `data` directory. The location depends on your OS. Run `show-config` to see where it will be stored now. If you have data in `~/.config/atomic/db`, move it to this new directory. Also, the search index will have to be rebuilt. Start with `--rebuild-index`.
 - Updated various dependencies, and made `cargo.toml` less restrictive.
 - Remove `async-std` calls from `upload.rs`
 - Added `reset` and `show-config` commands to `atomic-server`.
@@ -15,6 +14,7 @@ By far most changes relate to `atomic-server`, so if not specified, assume the c
 - Get rid of `.unwrap` calls in `commit_monitor` #345
 - Make process management optional #324 #334
 - Auto-update desktop distributions using Tauri #158
+- Internal migration logic for inter-version compatibility of the database. Makes upgrading trivial. #102
 
 ## [v0.31.1] - 2022-03-29
 

--- a/lib/src/db.rs
+++ b/lib/src/db.rs
@@ -21,6 +21,7 @@ use self::query_index::{
     update_indexed_member, watch_collection, IndexAtom, QueryFilter, END_CHAR,
 };
 
+mod migrations;
 mod query_index;
 #[cfg(test)]
 pub mod test;
@@ -47,7 +48,7 @@ pub struct Db {
     /// Try not to use this directly, but use the Trees.
     db: sled::Db,
     default_agent: Arc<Mutex<Option<crate::agents::Agent>>>,
-    /// Stores all resources. The Key is the Subject as a string, the value a [PropVals]. Both must be serialized using bincode.
+    /// Stores all resources. The Key is the Subject as a `string.as_bytes()`, the value a [PropVals]. Propvals must be serialized using [bincode].
     resources: sled::Tree,
     /// Index for all AtommicURLs, indexed by their Value. Used to speed up TPF queries. See [key_for_reference_index]
     reference_index: sled::Tree,
@@ -107,8 +108,7 @@ impl Db {
     #[instrument(skip(self))]
     fn set_propvals(&self, subject: &str, propvals: &PropVals) -> AtomicResult<()> {
         let resource_bin = bincode::serialize(propvals)?;
-        let subject_bin = bincode::serialize(subject)?;
-        self.resources.insert(subject_bin, resource_bin)?;
+        self.resources.insert(subject.as_bytes(), resource_bin)?;
         Ok(())
     }
 
@@ -116,11 +116,9 @@ impl Db {
     /// Deals with the binary API of Sled
     #[instrument(skip(self))]
     fn get_propvals(&self, subject: &str) -> AtomicResult<PropVals> {
-        let subject_binary = bincode::serialize(subject)
-            .map_err(|e| format!("Can't serialize {}: {}", subject, e))?;
         let propval_maybe = self
             .resources
-            .get(subject_binary)
+            .get(subject.as_bytes())
             .map_err(|e| format!("Can't open {} from store: {}", subject, e))?;
         match propval_maybe.as_ref() {
             Some(binpropval) => {
@@ -473,7 +471,7 @@ impl Storelike for Db {
             .expect("No self URL set, is required in DB");
         for item in self.resources.into_iter() {
             let (subject, resource_bin) = item.expect(DB_CORRUPT_MSG);
-            let subject: String = bincode::deserialize(&subject).expect(DB_CORRUPT_MSG);
+            let subject: String = String::from_utf8_lossy(&subject).to_string();
             if !include_external && !subject.starts_with(&self_url) {
                 continue;
             }
@@ -508,8 +506,7 @@ impl Storelike for Db {
                 let remove_atom = crate::Atom::new(subject.into(), prop.clone(), val.clone());
                 self.remove_atom_from_index(&remove_atom, &resource)?;
             }
-            let binary_subject = bincode::serialize(subject)?;
-            let _found = self.resources.remove(&binary_subject)?;
+            let _found = self.resources.remove(&subject.as_bytes())?;
         } else {
             return Err(format!(
                 "Resource {} could not be deleted, because it was not found in the store.",

--- a/lib/src/db.rs
+++ b/lib/src/db.rs
@@ -61,8 +61,6 @@ pub struct Db {
     /// A list of all the Collections currently being used. Is used to update `members_index`.
     /// See [collections_index]
     watched_queries: sled::Tree,
-    /// Contains settings such as schema versions.
-    internal: sled::Tree,
     /// The address where the db will be hosted, e.g. http://localhost/
     server_url: String,
     /// Endpoints are checked whenever a resource is requested. They calculate (some properties of) the resource and return it.
@@ -79,7 +77,6 @@ impl Db {
         let reference_index = db.open_tree("reference_index")?;
         let members_index = db.open_tree("members_index")?;
         let watched_queries = db.open_tree("watched_queries")?;
-        let internal = db.open_tree("internal")?;
         let store = Db {
             db,
             default_agent: Arc::new(Mutex::new(None)),
@@ -89,7 +86,6 @@ impl Db {
             server_url,
             watched_queries,
             endpoints: default_endpoints(),
-            internal,
         };
         migrate_maybe(&store)?;
         crate::populate::populate_base_models(&store)

--- a/lib/src/db.rs
+++ b/lib/src/db.rs
@@ -75,7 +75,7 @@ impl Db {
     /// It is used for distinguishing locally defined items from externally defined ones.
     pub fn init(path: &std::path::Path, server_url: String) -> AtomicResult<Db> {
         let db = sled::open(path).map_err(|e|format!("Failed opening DB at this location: {:?} . Is another instance of Atomic Server running? {}", path, e))?;
-        let resources = db.open_tree("resources").map_err(|e|format!("Failed building resources. Your DB might be corrupt. Go back to a previous version and export your data. {}", e))?;
+        let resources = db.open_tree("resources_v1").map_err(|e|format!("Failed building resources. Your DB might be corrupt. Go back to a previous version and export your data. {}", e))?;
         let reference_index = db.open_tree("reference_index")?;
         let members_index = db.open_tree("members_index")?;
         let watched_queries = db.open_tree("watched_queries")?;

--- a/lib/src/db/migrations.rs
+++ b/lib/src/db/migrations.rs
@@ -1,0 +1,20 @@
+/*!
+# Migrations
+
+Whenever the schema of the database changes, a newer version will not be able to read an older database.
+Therefore, we need migrations to convert the old schema to the new one.
+ */
+
+use crate::{errors::AtomicResult, Db};
+
+// Change the subjects from `bincode` to `.as_bytes()`
+fn v0_to_v1(store: &mut Db) -> AtomicResult<()> {
+    let new = store.db.open_tree("resources_new")?;
+    for item in store.resources.into_iter() {
+        let (subject, resource_bin) = item.expect("Unable to perform migration");
+        let subject: String =
+            bincode::deserialize(&subject).expect("Unable to deserialize subject");
+        new.insert(subject.as_bytes(), resource_bin)?;
+    }
+    Ok(())
+}

--- a/lib/src/db/migrations.rs
+++ b/lib/src/db/migrations.rs
@@ -7,76 +7,56 @@ Therefore, we need migrations to convert the old schema to the new one.
 ## Adding a Migration
 
 - Write a function called `v{OLD}_to_v{NEW} that takes a [Db].
-- Update the relevant version key in your function
-- Update [SCHEMA_RESOURCES_VERSION_APP]
-- Add the function to the [migrate_maybe] `match` statement
+- In [migrate_maybe] add the key of the outdated Tree
+- Add the function to the [migrate_maybe] `match` statement, select the older version of the Tree
+- Update the Tree key used in [Db::init]
  */
 
 use crate::{errors::AtomicResult, Db};
 
-static SCHEMA_RESOURCES_VERSION_APP: &str = "1";
-static SCHEMA_RESOURCES_VERSION_KEY: &str = "schema_resources_version";
-
-// Checks the current version(s) of the internal Store, and performs migrations if needed.
+/// Checks the current version(s) of the internal Store, and performs migrations if needed.
 pub fn migrate_maybe(store: &Db) -> AtomicResult<()> {
-    let schema_resource_version: String = if let Some(v) = &store
-        .internal
-        .get(SCHEMA_RESOURCES_VERSION_KEY.as_bytes())?
-    {
-        String::from_utf8_lossy(v).to_string()
-    } else {
-        "0".into()
-    };
-
-    match schema_resource_version.as_str() {
-        // Add your migration to this list
-        "0" => v0_to_v1(store),
-        other => {
-            if other == SCHEMA_RESOURCES_VERSION_APP {
-                Ok(())
-            } else {
-                Err(format!(
-                    "Unable to perform migration, unknown current schema version: {}",
-                    other
-                )
-                .into())
-            }
+    for tree in store.db.tree_names() {
+        match String::from_utf8_lossy(&tree).as_ref() {
+            // Add migrations for outdated Trees to this list
+            "resources" => v0_to_v1(store)?,
+            _other => {}
         }
     }
+    Ok(())
 }
 
-// Change the subjects from `bincode` to `.as_bytes()`
+/// Change the subjects from `bincode` to `.as_bytes()`
 fn v0_to_v1(store: &Db) -> AtomicResult<()> {
     tracing::warn!("Migrating resources schema from v0 to v1...");
-    let new = store.db.open_tree("resources_new_temp")?;
+    let new = store.db.open_tree("resources_v1")?;
     let mut count = 0;
 
-    // use sled::Transactional;
+    let config = sled::Config::new().temporary(true);
+    let db = config.open().unwrap();
 
-    // (&store.resources, &new).transaction(|(old, new)| {
-    //     for item in store.resources.into_iter() {
-    //         let (subject, resource_bin) = item.expect("Unable to perform migration");
-    //         let subject: String =
-    //             bincode::deserialize(&subject).expect("Unable to deserialize subject");
-    //         new.insert(subject.as_bytes(), resource_bin)?;
-    //         count += 1;
-    //     }
-    //     Ok(())
-    // });
+    use sled::Transactional;
 
-    for item in store.resources.into_iter() {
-        let (subject, resource_bin) = item.expect("Unable to perform migration");
-        let subject: String =
-            bincode::deserialize(&subject).expect("Unable to deserialize subject");
-        new.insert(subject.as_bytes(), resource_bin)?;
-        count += 1;
-    }
+    // TODO: Let this compile!:
+    // https://github.com/spacejam/sled/issues/1406
+    // (&store.resources, &new)
+    //     .transaction(|(old, new)| {
+    //         for item in store.resources.into_iter() {
+    //             let (subject, resource_bin) = item.expect("Unable to perform migration");
+    //             let subject: String =
+    //                 bincode::deserialize(&subject).expect("Unable to deserialize subject");
+    //             new.insert(subject.as_bytes(), resource_bin)?;
+    //             count += 1;
+    //         }
+    //         Ok(())
+    //     })
+    //     .expect("Unable to perform migration");
+
     assert_eq!(
         new.len(),
         store.resources.len(),
         "Not all resources were migrated."
     );
     tracing::warn!("Finished migration of {} resources", count);
-    store.internal.insert(SCHEMA_RESOURCES_VERSION_KEY, b"1")?;
     Ok(())
 }

--- a/lib/src/db/migrations.rs
+++ b/lib/src/db/migrations.rs
@@ -3,31 +3,80 @@
 
 Whenever the schema of the database changes, a newer version will not be able to read an older database.
 Therefore, we need migrations to convert the old schema to the new one.
+
+## Adding a Migration
+
+- Write a function called `v{OLD}_to_v{NEW} that takes a [Db].
+- Update the relevant version key in your function
+- Update [SCHEMA_RESOURCES_VERSION_APP]
+- Add the function to the [migrate_maybe] `match` statement
  */
 
 use crate::{errors::AtomicResult, Db};
 
-// Checks the current version(s) of the internal Store, and performs migrations if needed.
-fn migrate_maybe(store: &mut Db) -> AtomicResult<()> {
-    let internal = store.db.open_tree("internal")?;
+static SCHEMA_RESOURCES_VERSION_APP: &str = "1";
+static SCHEMA_RESOURCES_VERSION_KEY: &str = "schema_resources_version";
 
-    let version: i16 = if let Some(v) = internal.get(b"version_resources")? {
-        v.try_into()?
+// Checks the current version(s) of the internal Store, and performs migrations if needed.
+pub fn migrate_maybe(store: &Db) -> AtomicResult<()> {
+    let schema_resource_version: String = if let Some(v) = &store
+        .internal
+        .get(SCHEMA_RESOURCES_VERSION_KEY.as_bytes())?
+    {
+        String::from_utf8_lossy(v).to_string()
     } else {
-        0
+        "0".into()
     };
 
-    Ok(())
+    match schema_resource_version.as_str() {
+        // Add your migration to this list
+        "0" => v0_to_v1(store),
+        other => {
+            if other == SCHEMA_RESOURCES_VERSION_APP {
+                Ok(())
+            } else {
+                Err(format!(
+                    "Unable to perform migration, unknown current schema version: {}",
+                    other
+                )
+                .into())
+            }
+        }
+    }
 }
 
 // Change the subjects from `bincode` to `.as_bytes()`
-fn v0_to_v1(store: &mut Db) -> AtomicResult<()> {
+fn v0_to_v1(store: &Db) -> AtomicResult<()> {
+    tracing::warn!("Migrating resources schema from v0 to v1...");
     let new = store.db.open_tree("resources_new_temp")?;
+    let mut count = 0;
+
+    // use sled::Transactional;
+
+    // (&store.resources, &new).transaction(|(old, new)| {
+    //     for item in store.resources.into_iter() {
+    //         let (subject, resource_bin) = item.expect("Unable to perform migration");
+    //         let subject: String =
+    //             bincode::deserialize(&subject).expect("Unable to deserialize subject");
+    //         new.insert(subject.as_bytes(), resource_bin)?;
+    //         count += 1;
+    //     }
+    //     Ok(())
+    // });
+
     for item in store.resources.into_iter() {
         let (subject, resource_bin) = item.expect("Unable to perform migration");
         let subject: String =
             bincode::deserialize(&subject).expect("Unable to deserialize subject");
         new.insert(subject.as_bytes(), resource_bin)?;
+        count += 1;
     }
+    assert_eq!(
+        new.len(),
+        store.resources.len(),
+        "Not all resources were migrated."
+    );
+    tracing::warn!("Finished migration of {} resources", count);
+    store.internal.insert(SCHEMA_RESOURCES_VERSION_KEY, b"1")?;
     Ok(())
 }

--- a/lib/src/db/migrations.rs
+++ b/lib/src/db/migrations.rs
@@ -7,9 +7,22 @@ Therefore, we need migrations to convert the old schema to the new one.
 
 use crate::{errors::AtomicResult, Db};
 
+// Checks the current version(s) of the internal Store, and performs migrations if needed.
+fn migrate_maybe(store: &mut Db) -> AtomicResult<()> {
+    let internal = store.db.open_tree("internal")?;
+
+    let version: i16 = if let Some(v) = internal.get(b"version_resources")? {
+        v.try_into()?
+    } else {
+        0
+    };
+
+    Ok(())
+}
+
 // Change the subjects from `bincode` to `.as_bytes()`
 fn v0_to_v1(store: &mut Db) -> AtomicResult<()> {
-    let new = store.db.open_tree("resources_new")?;
+    let new = store.db.open_tree("resources_new_temp")?;
     for item in store.resources.into_iter() {
         let (subject, resource_bin) = item.expect("Unable to perform migration");
         let subject: String =

--- a/server/e2e_tests/e2e.spec.ts
+++ b/server/e2e_tests/e2e.spec.ts
@@ -117,7 +117,7 @@ test.describe('data-browser', async () => {
     await page.click('[data-test="next-page"]');
     await expect(page.locator('text=A base64')).not.toBeVisible();
     // Some item on the second page. Can change as the amount of properties grows!
-    await expect(page.locator('text=that are not required')).toBeVisible();
+    await expect(page.locator('text=should be given the rights')).toBeVisible();
 
     // context menu, keyboard & data view
     await page.click('[data-test="context-menu"]');

--- a/server/src/bin.rs
+++ b/server/src/bin.rs
@@ -74,6 +74,7 @@ async fn main() -> errors::AtomicServerResult<()> {
                 .unwrap()
             {
                 std::fs::remove_dir_all(config.store_path).map(|e| format!("unable to remove directory: {:?}", e))?;
+                std::fs::remove_dir_all(config.search_index_path).map(|e| format!("unable to remove directory: {:?}", e))?;
                 println!("Done");
             } else {
                 println!("Ok, not removing anything.");


### PR DESCRIPTION
Enables automated migrations for making schema changes in the sled store

- [x] Don't use `bincode` for subjects  closes #384
- [x] Migrations are run on boot

PR Checklist:

- [x] Link to related issue closes #102
- [ ] Add changelog entry linking to issue
- [ ] Added tests (if needed)
- [ ] (If new feature) added in description / readme
